### PR TITLE
Invalid Size Check for Marc Tag in StreamWriter

### DIFF
--- a/MARC4J.Net/MarcStreamWriter.cs
+++ b/MARC4J.Net/MarcStreamWriter.cs
@@ -243,7 +243,7 @@ namespace MARC4J.Net
         protected byte[] GetEntry(String tag, int length, int start)
         {
             String entryUse = tag + length.ToString().PadLeft(4, '0') + start.ToString().PadLeft(5, '0');
-            if (length > 99999) hasOversizeLength = true;
+            if (length > 9999) hasOversizeLength = true;
             if (start > 99999) hasOversizeOffset = true;
             return encoding.GetBytes(entryUse);
         }


### PR DESCRIPTION
A valid marc record in marc 21 format can have field tag size of maximum
9999 bytes. The whole marc record cannot exceed 99999 bytes. If a tag
field have size greater than 9999 bytes, then the directory parsing
fails. If allowOversizeEntry is false, then marc stream writer should
not allow, invalid sizes.
Ref : http://www.loc.gov/marc/bibliographic/bddirectory.html
